### PR TITLE
Decrease purescript-maps lower bound

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,6 @@
     "purescript-exceptions": "v0.3.0",
     "purescript-prelude": "<= 0.1.1",
     "purescript-dom": "^0.1.2",
-    "purescript-maps": "^0.5.0"
+    "purescript-maps": "^0.4.0"
   }
 }


### PR DESCRIPTION
This is to avoid causing dependency version churn in packages that will depend on this library. (`purescript-markdown-halogen` in particular).
