### PR TITLE
Dependency version wrangling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,9 @@ language: node_js
 sudo: false
 node_js:
   - 0.12.7
-env:
-  - PATH=$HOME/purescript:$PATH
 install:
-  - TAG=$(wget -q -O - https://github.com/purescript/purescript/releases/latest --server-response --max-redirect 0 2>&1 | sed -n -e 's/.*Location:.*tag\///p')
-  - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
-  - tar -xvf $HOME/purescript.tar.gz -C $HOME/
-  - chmod a+x $HOME/purescript
+  - npm install -g gulp bower
   - npm install
-  - npm install -g bower
   - bower install
 script:
   - npm run build

--- a/bower.json
+++ b/bower.json
@@ -10,15 +10,18 @@
   ],
   "description": "A data type for browser features and detectors to test for the features",
   "keywords": [
-    "purescript",
-    "platform"
+    "purescript"
   ],
   "license": "Apache-2.0",
   "dependencies": {
     "purescript-base": "^0.1.0",
-    "purescript-exceptions": "v0.3.0",
-    "purescript-prelude": "<= 0.1.1",
+    "purescript-exceptions": "^0.3.0",
+    "purescript-prelude": "^0.1.2",
     "purescript-dom": "^0.1.2",
-    "purescript-maps": "^0.4.0"
+    "purescript-maps": "^0.4.0",
+    "purescript-strings": "^0.7.0"
+  },
+  "resolutions": {
+    "purescript-strings": "^0.7.0"
   }
 }


### PR DESCRIPTION
This PR is hopefully the last dependency-quicksand-treading one that I will have to submit for a little while :). The changes included here were done in order to make this library compatible with `purescript-markdown-halogen` and `slamdata`.

The primary change is to bump the lower bound of `purescript-prelude` to `^0.1.2`; additionally, I have simplified the Travis install script to allow `npm` to install `psc`.
##### verifications of compatibility

I have built a special version of `purescript-markdown-halogen` against this branch to be sure that it builds properly:  https://travis-ci.org/jonsterling/purescript-markdown-halogen/builds/79322377

Next, I built a version of `slamdata` that would use the above branch of `purescript-markdown-halogen`, to ensure that that would build properly as well: https://travis-ci.org/jonsterling/slamdata/builds/79323068

@cryogenian or @beckyconning Would you mind looking this over and merging if it seems OK?
