### PR TITLE
Memoize feature detection (resolve #5)

### DIFF
--- a/src/DOM/BrowserFeatures/Detectors.js
+++ b/src/DOM/BrowserFeatures/Detectors.js
@@ -1,7 +1,13 @@
 // module DOM.BrowserFeatures.Detectors
 
+var _inputTypeSupportMemoTable = {};
+
 exports._detectInputTypeSupport = function(type) {
   return function() {
+    if (_inputTypeSupportMemoTable.hasOwnProperty(type)) {
+      return _inputTypeSupportMemoTable[type];
+    }
+
     var el = document.createElement("input");
 
     try {
@@ -10,6 +16,9 @@ exports._detectInputTypeSupport = function(type) {
       return false;
     }
 
-    return el.type === type;
+    var result = el.type === type;
+    _inputTypeSupportMemoTable[type] = result;
+
+    return result;
   };
 };

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -11,6 +11,13 @@ import DOM.BrowserFeatures.Detectors
 
 main :: Eff (dom :: DOM, console :: CONSOLE) Unit
 main = do
-  features <- detectBrowserFeatures
-  void $ for IT.allInputTypes \ty ->
-    log $ show ty ++ if features.inputTypeSupported ty then " supported" else " not supported"
+  queryFeatureSupport
+  log "Will query feature support again, using memoized results"
+  queryFeatureSupport
+  log "Done"
+
+  where
+    queryFeatureSupport = do
+      features <- detectBrowserFeatures
+      void $ for IT.allInputTypes \ty ->
+        log $ show ty ++ if features.inputTypeSupported ty then " supported" else " not supported"


### PR DESCRIPTION
This adds memoization to the feature detectors; the code should be observationally/extensionally equivalent to the old code.
