### PR TITLE
Bump deps; implement detectInputTypeSupport in terms of purescript-dom

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "purescript-base": "^0.2.0",
     "purescript-exceptions": "^0.3.0",
     "purescript-prelude": "^0.1.2",
-    "purescript-dom": "^0.1.2",
-    "purescript-maps": "^0.4.0"
+    "purescript-dom": "^0.2.6",
+    "purescript-maps": "^0.5.0",
+    "purescript-refs": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-purescript": "^0.5.0",
-    "purescript": "^0.7.1",
+    "purescript": "^0.7.4",
     "webpack-stream": "^2.1.0"
   },
   "dependencies": {

--- a/src/DOM/BrowserFeatures/Detectors.js
+++ b/src/DOM/BrowserFeatures/Detectors.js
@@ -1,24 +1,7 @@
 // module DOM.BrowserFeatures.Detectors
 
-var _inputTypeSupportMemoTable = {};
-
-exports._detectInputTypeSupport = function(type) {
-  return function() {
-    if (_inputTypeSupportMemoTable.hasOwnProperty(type)) {
-      return _inputTypeSupportMemoTable[type];
-    }
-
-    var el = document.createElement("input");
-
-    try {
-      el.setAttribute("type", type);
-    } catch (exn) {
-      return false;
-    }
-
-    var result = el.type === type;
-    _inputTypeSupportMemoTable[type] = result;
-
-    return result;
+exports._getTypeProperty = function (el) {
+  return function () {
+    return el.type;
   };
 };


### PR DESCRIPTION
Resolves #8

@garyb Would you mind reviewing this? In particular, I didn't think I should have needed all three instances of `unsafeInterleaveEff` (it seemed like the one around `f i` should have been unnecessary, but perhaps I am thinking about the variance incorrectly), but I couldn't figure out a way around it in the naïve way.
