### PR TITLE
Fix warnings; update build

### DIFF
--- a/docs/Data/BrowserFeatures/InputType.md
+++ b/docs/Data/BrowserFeatures/InputType.md
@@ -21,9 +21,9 @@ data InputType
 
 ##### Instances
 ``` purescript
-instance showInputType :: Show InputType
-instance eqInputType :: Eq InputType
-instance ordInputType :: Ord InputType
+Show InputType
+Eq InputType
+Ord InputType
 ```
 
 #### `allInputTypes`

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-purescript": "^0.5.0",
-    "purescript": "^0.7.4",
+    "gulp-purescript": "^0.7.0",
+    "purescript": "^0.7.6",
     "webpack-stream": "^2.1.0"
   },
   "dependencies": {

--- a/src/DOM/BrowserFeatures/Detectors.purs
+++ b/src/DOM/BrowserFeatures/Detectors.purs
@@ -4,17 +4,14 @@ module DOM.BrowserFeatures.Detectors
 
 import Prelude
 import Control.Monad.Eff
-import Control.Monad.Eff.Class (liftEff)
 import qualified Control.Monad.Eff.Unsafe as Unsafe
 import Control.Monad.Eff.Exception
 import Control.Monad.Eff.Ref
 
-import qualified Data.Array as Arr
 import qualified Data.List as L
 import qualified Data.Map as M
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Foldable (foldr)
-import qualified Data.Nullable as Nullable
 import Data.Traversable (traverse)
 import Data.Tuple
 

--- a/src/Data/BrowserFeatures/InputType.purs
+++ b/src/Data/BrowserFeatures/InputType.purs
@@ -5,7 +5,6 @@ module Data.BrowserFeatures.InputType
   ) where
 
 import Prelude
-import qualified Data.Array as Arr
 
 data InputType
   = Color

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,7 +4,7 @@ import Prelude
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Console (CONSOLE(), log)
 
-import Data.Traversable (traverse, for)
+import Data.Traversable (for)
 import qualified Data.BrowserFeatures.InputType as IT
 import DOM
 import DOM.BrowserFeatures.Detectors


### PR DESCRIPTION
Purescript `0.7.6` seems to do a nice job of finding unused imports!

This should merit only a patch version increment so that warnings can be silently fixed in projects that depend on this.
