### PR TITLE
Migrate to Purescript 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,13 +14,12 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "purescript-dom": "^4.0.0",
-    "purescript-exceptions": "^3.0.0",
-    "purescript-maps": "^3.0.0",
-    "purescript-prelude": "^3.0.0",
-    "purescript-refs": "^3.0.0"
+    "purescript-exceptions": "^4.0.0",
+    "purescript-ordered-collections": "^1.4.0",
+    "purescript-prelude": "^4.0.0",
+    "purescript-refs": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^3.0.0"
+    "purescript-console": "^4.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,9 @@
     "purescript-exceptions": "^4.0.0",
     "purescript-ordered-collections": "^1.4.0",
     "purescript-prelude": "^4.0.0",
-    "purescript-refs": "^4.0.0"
+    "purescript-refs": "^4.0.0",
+    "purescript-web-dom": "^1.0.0",
+    "purescript-web-html": "^1.0.0"
   },
   "devDependencies": {
     "purescript-console": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "easyimage": "^2.1.0",
     "jscs": "^3.0.7",
     "jshint": "^2.9.4",
-    "pulp": "^11.0.0",
-    "purescript-psa": "^0.5.0",
-    "purescript": "^0.11.4",
+    "pulp": "^12.3.0",
+    "purescript-psa": "^0.6.0",
+    "purescript": "^0.12.0",
     "rimraf": "^2.5.4"
   }
 }

--- a/src/DOM/BrowserFeatures/Detectors.purs
+++ b/src/DOM/BrowserFeatures/Detectors.purs
@@ -8,6 +8,7 @@ import Effect (Effect)
 import Effect.Exception (catchException)
 -- import Control.Monad.Eff.Ref (modifyRef, readRef, newRef)
 import Effect.Unsafe as Unsafe
+import Effect.Ref (new, read, modify_)
 
 import Data.BrowserFeatures (BrowserFeatures)
 import Data.BrowserFeatures.InputType as IT
@@ -33,14 +34,14 @@ type InputTypeMap = M.Map IT.InputType Boolean
 memoizeEff :: forall i o. (Ord i) => (i -> Effect o) -> i -> Effect o
 memoizeEff f =
   Unsafe.unsafePerformEffect $ do
-    cacheRef <- ?newRef M.empty
+    cacheRef <- new M.empty
     pure \i -> Unsafe.unsafePerformEffect $ do
-      cache <- ?readRef cacheRef
+      cache <- read cacheRef
       case M.lookup i cache of
         Just o -> pure o
         Nothing -> do
-          o <- Unsafe.unsafePerformEffect $ f i
-          ?modifyRef cacheRef (M.insert i o)
+          o <- f i
+          modify_ (M.insert i o) cacheRef 
           pure o
 
 detectInputTypeSupport :: IT.InputType -> Effect Boolean

--- a/src/DOM/BrowserFeatures/Detectors.purs
+++ b/src/DOM/BrowserFeatures/Detectors.purs
@@ -32,7 +32,7 @@ type InputTypeMap = M.Map IT.InputType Boolean
 -- | effect.
 memoizeEff :: forall i o. (Ord i) => (i -> Effect o) -> i -> Effect o
 memoizeEff f =
-  ?runPure <<< Unsafe.unsafePerformEffect $ do
+  Unsafe.unsafePerformEffect $ do
     cacheRef <- ?newRef M.empty
     pure \i -> Unsafe.unsafePerformEffect $ do
       cache <- ?readRef cacheRef

--- a/test/src/Main.purs
+++ b/test/src/Main.purs
@@ -2,16 +2,15 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, log)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Data.BrowserFeatures.InputType as IT
 import Data.Traversable (for)
 
-import DOM (DOM)
 import DOM.BrowserFeatures.Detectors (detectBrowserFeatures)
 
-main :: Eff (dom :: DOM, console :: CONSOLE) Unit
+main :: Effect Unit
 main = do
   queryFeatureSupport
   log "Will query feature support again, using memoized results"


### PR DESCRIPTION
Having a bit of a brain failure with understanding the old implementation of the memoizeEff function.

Hopefully a fresh crack later can allow me to provide the missing implementation and then migrate the tests.